### PR TITLE
Typo ?

### DIFF
--- a/web/doc.html
+++ b/web/doc.html
@@ -216,7 +216,7 @@ To enable code generation, we add some annotations:
   } [@@ocf]
 </oc>
 <p>
-To trigger the generation, the type definition must have a <ml>[@@ocf]></ml>
+To trigger the generation, the type definition must have a <ml>[@@ocf]</ml>
 attribute.
 Each field can have a <ml>[@ocf ]</ml> attribute (on the type)
 with a pair of expressions. The first part of the pair is the wrapper,


### PR DESCRIPTION
It appears like this on thewebpage:
[truncated]

must have a `[@@ocf]>` attribute.